### PR TITLE
3 create a schedule service base

### DIFF
--- a/.github/skills/github-actions-failure-debugging/SKILL.md
+++ b/.github/skills/github-actions-failure-debugging/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: github-actions-failure-debugging
+description: Guide for debugging failing GitHub Actions workflows. Use this when asked to debug failing GitHub Actions workflows.
+---
+
+To debug failing GitHub Actions workflows in a pull request, follow this process, using tools provided from the GitHub MCP Server:
+
+1. Use the `list_workflow_runs` tool to look up recent workflow runs for the pull request and their status
+2. Use the `summarize_job_log_failures` tool to get an AI summary of the logs for failed jobs, to understand what went wrong without filling your context windows with thousands of lines of logs
+3. If you still need more information, use the `get_job_logs` or `get_workflow_run_logs` tool to get the full, detailed failure logs
+4. Try to reproduce the failure yourself in your own environment.
+5. Fix the failing build. If you were able to reproduce the failure yourself, make sure it is fixed before committing your changes.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - "**"
 
 env:
   DOTNET_VERSION: "8.x"
@@ -35,4 +35,5 @@ jobs:
         run: dotnet test BookKeeper.sln --configuration Release --no-restore --no-build
 
       - name: Publish
+        if: github.ref == 'refs/heads/main'
         run: dotnet publish BookKeeper.sln --configuration Release --no-restore --no-build

--- a/BookKeeper/BookKeeper/BookKeeper.Api/BookKeeper.Api.csproj
+++ b/BookKeeper/BookKeeper/BookKeeper.Api/BookKeeper.Api.csproj
@@ -24,7 +24,11 @@
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+		<PackageReference Include="OpenTelemetry.Instrumentation.Quartz" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
+		<PackageReference Include="Quartz.Extensions.DependencyInjection" />
+		<PackageReference Include="Quartz.Extensions.Hosting" />
+		<PackageReference Include="Quartz.Serialization.Json" />
 		<PackageReference Include="Swashbuckle.AspNetCore" />
 		<PackageReference Include="Ulid" />
 	</ItemGroup>

--- a/BookKeeper/BookKeeper/BookKeeper.Api/DependencyInjection.cs
+++ b/BookKeeper/BookKeeper/BookKeeper.Api/DependencyInjection.cs
@@ -19,6 +19,7 @@ using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using Quartz;
 
 namespace BookKeeper.Api;
 
@@ -84,7 +85,8 @@ public static class DependencyInjection
             .WithTracing(tracing => tracing
                 .AddHttpClientInstrumentation()
                 .AddAspNetCoreInstrumentation()
-                .AddNpgsql())
+                .AddNpgsql()
+                .AddQuartzInstrumentation())
             .WithMetrics(metrics => metrics
                 .AddHttpClientInstrumentation()
                 .AddAspNetCoreInstrumentation()
@@ -150,6 +152,23 @@ public static class DependencyInjection
             });
 
         builder.Services.AddAuthorization();
+
+        return builder;
+    }
+
+    public static WebApplicationBuilder AddQuartz(this WebApplicationBuilder builder)
+    {
+        builder.Services.AddQuartz(configurator =>
+        {
+            var scheduler = Guid.NewGuid();
+            configurator.SchedulerId = $"default-id-{scheduler}";
+            configurator.SchedulerName = $"default-name-{scheduler}";
+        });
+
+        builder.Services.AddQuartzHostedService(options =>
+        {
+            options.WaitForJobsToComplete = true;
+        });
 
         return builder;
     }

--- a/BookKeeper/BookKeeper/BookKeeper.Api/DependencyInjection.cs
+++ b/BookKeeper/BookKeeper/BookKeeper.Api/DependencyInjection.cs
@@ -160,9 +160,9 @@ public static class DependencyInjection
     {
         builder.Services.AddQuartz(configurator =>
         {
-            var scheduler = Guid.NewGuid();
-            configurator.SchedulerId = $"default-id-{scheduler}";
-            configurator.SchedulerName = $"default-name-{scheduler}";
+            var schedulerId = Guid.NewGuid();
+            configurator.SchedulerId = $"default-id-{schedulerId}";
+            configurator.SchedulerName = $"default-name-{schedulerId}";
         });
 
         builder.Services.AddQuartzHostedService(options =>

--- a/BookKeeper/BookKeeper/BookKeeper.Api/Program.cs
+++ b/BookKeeper/BookKeeper/BookKeeper.Api/Program.cs
@@ -6,9 +6,10 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.AddApiService()
     .AddMediaR()
+    .AddQuartz()
     .AddErrorHandling()
     .AddDatabase()
-    .AddObservability() 
+    .AddObservability()
     .AddApplicationServices()
     .AddAuthenticationService();
 

--- a/BookKeeper/BookKeeper/Directory.Packages.props
+++ b/BookKeeper/BookKeeper/Directory.Packages.props
@@ -17,7 +17,11 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.13.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Quartz" Version="1.14.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="Quartz.Extensions.DependencyInjection" Version="3.15.1" />
+    <PackageVersion Include="Quartz.Extensions.Hosting" Version="3.15.1" />
+    <PackageVersion Include="Quartz.Serialization.Json" Version="3.15.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" />
     <PackageVersion Include="Ulid" Version="1.4.1" />

--- a/MyBookKeeper.drawio
+++ b/MyBookKeeper.drawio
@@ -1,79 +1,91 @@
-<mxfile host="Electron" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/29.0.3 Chrome/140.0.7339.249 Electron/38.7.0 Safari/537.36" version="29.0.3" pages="5">
+<mxfile host="Electron" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/29.3.0 Chrome/140.0.7339.249 Electron/38.7.2 Safari/537.36" version="29.3.0" pages="5">
   <diagram id="RMgL5czDVNAjeAsPA6hz" name="Level1">
-    <mxGraphModel dx="936" dy="537" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="1665" dy="875" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
-        <mxCell id="1" style="locked=1;" parent="0" />
-        <mxCell id="8GixQCTYSWXH89NHeWw2-1" value="標籤" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="320" y="280" width="120" height="60" as="geometry" />
+        <mxCell id="1" parent="0" style="locked=1;" />
+        <mxCell id="8GixQCTYSWXH89NHeWw2-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="標籤" vertex="1">
+          <mxGeometry height="60" width="120" x="320" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="8GixQCTYSWXH89NHeWw2-2" value="資料匯出" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="80" y="280" width="120" height="60" as="geometry" />
+        <mxCell id="8GixQCTYSWXH89NHeWw2-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="資料匯出" vertex="1">
+          <mxGeometry height="60" width="120" x="80" y="280" as="geometry" />
         </mxCell>
-        <mxCell id="8GixQCTYSWXH89NHeWw2-3" value="支出" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="80" y="80" width="120" height="60" as="geometry" />
+        <mxCell id="8GixQCTYSWXH89NHeWw2-3" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="支出" vertex="1">
+          <mxGeometry height="60" width="120" x="80" y="80" as="geometry" />
         </mxCell>
-        <mxCell id="8GixQCTYSWXH89NHeWw2-4" value="收入" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="320" y="80" width="120" height="60" as="geometry" />
+        <mxCell id="8GixQCTYSWXH89NHeWw2-4" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="收入" vertex="1">
+          <mxGeometry height="60" width="120" x="320" y="80" as="geometry" />
+        </mxCell>
+        <mxCell id="1atQuJQ4bqYq-Z0UaQ7x-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="使用者" vertex="1">
+          <mxGeometry height="60" width="120" x="560" y="80" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>
   </diagram>
   <diagram name="Level2" id="bxbMu0wlwAWbULQVKam2">
-    <mxGraphModel dx="936" dy="537" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="1665" dy="875" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
-        <mxCell id="1" style="locked=1;" parent="0" />
-        <mxCell id="96d6q6x4AIGhJgeAviht-1" value="一般支出紀錄" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="210" y="130" width="120" height="60" as="geometry" />
+        <mxCell id="1" parent="0" style="locked=1;" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="一般支出紀錄" vertex="1">
+          <mxGeometry height="60" width="120" x="210" y="130" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-2" value="一般收入紀錄" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="640" y="130" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="一般收入紀錄" vertex="1">
+          <mxGeometry height="60" width="120" x="640" y="130" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-15" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-3" target="96d6q6x4AIGhJgeAviht-7" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-15" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="96d6q6x4AIGhJgeAviht-7">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-3" target="96d6q6x4AIGhJgeAviht-14" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-16" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="96d6q6x4AIGhJgeAviht-14">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-3" value="標籤" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="460" y="440" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-3" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="標籤" vertex="1">
+          <mxGeometry height="60" width="120" x="460" y="440" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-4" value="定期支出紀錄" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="210" y="260" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-4" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="定期支出紀錄" vertex="1">
+          <mxGeometry height="60" width="120" x="210" y="260" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-5" value="定期收入紀錄" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="640" y="240" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-5" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="定期收入紀錄" vertex="1">
+          <mxGeometry height="60" width="120" x="640" y="240" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-6" value="資料匯出" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="50" y="440" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-6" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="資料匯出" vertex="1">
+          <mxGeometry height="60" width="120" x="50" y="440" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-7" value="標籤管理" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="640" y="440" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-7" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="標籤管理" vertex="1">
+          <mxGeometry height="60" width="120" x="640" y="440" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-8" target="96d6q6x4AIGhJgeAviht-1" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-9" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="96d6q6x4AIGhJgeAviht-1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-8" target="96d6q6x4AIGhJgeAviht-4" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-10" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="96d6q6x4AIGhJgeAviht-4">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-8" value="支出" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="50" y="130" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-8" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="支出" vertex="1">
+          <mxGeometry height="60" width="120" x="50" y="130" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-12" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-11" target="96d6q6x4AIGhJgeAviht-2" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-12" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" target="96d6q6x4AIGhJgeAviht-2">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-13" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="96d6q6x4AIGhJgeAviht-11" target="96d6q6x4AIGhJgeAviht-5" edge="1">
+        <mxCell id="96d6q6x4AIGhJgeAviht-13" edge="1" parent="1" source="96d6q6x4AIGhJgeAviht-11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" target="96d6q6x4AIGhJgeAviht-5">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-11" value="收入" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" parent="1" vertex="1">
-          <mxGeometry x="465" y="130" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-11" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="收入" vertex="1">
+          <mxGeometry height="60" width="120" x="465" y="130" as="geometry" />
         </mxCell>
-        <mxCell id="96d6q6x4AIGhJgeAviht-14" value="AI智慧標籤" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;dashed=1;" parent="1" vertex="1">
-          <mxGeometry x="640" y="540" width="120" height="60" as="geometry" />
+        <mxCell id="96d6q6x4AIGhJgeAviht-14" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;dashed=1;" value="AI智慧標籤" vertex="1">
+          <mxGeometry height="60" width="120" x="640" y="540" as="geometry" />
         </mxCell>
-        <mxCell id="HqLdmnazgUCmsoDpUc1q-1" value="Feature" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;" parent="1" vertex="1">
-          <mxGeometry x="730" y="560" width="120" height="80" as="geometry" />
+        <mxCell id="HqLdmnazgUCmsoDpUc1q-1" parent="1" style="ellipse;shape=cloud;whiteSpace=wrap;html=1;" value="Feature" vertex="1">
+          <mxGeometry height="80" width="120" x="730" y="560" as="geometry" />
+        </mxCell>
+        <mxCell id="-0a_q8MK7DopLSxAY8Tf-3" edge="1" parent="1" source="-0a_q8MK7DopLSxAY8Tf-1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;" target="-0a_q8MK7DopLSxAY8Tf-2" value="">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="-0a_q8MK7DopLSxAY8Tf-1" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="使用者" vertex="1">
+          <mxGeometry height="60" width="120" x="60" y="680" as="geometry" />
+        </mxCell>
+        <mxCell id="-0a_q8MK7DopLSxAY8Tf-2" parent="1" style="rounded=0;whiteSpace=wrap;html=1;fontSize=15;" value="帳號註冊" vertex="1">
+          <mxGeometry height="60" width="120" x="210" y="680" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
### 功能說明

在本專案中新增排程服務（Scheduling Service）相關的基礎架構，並導入 Quartz 套件作為主要排程工具，作為後續排程功能開發的基礎。

---

### 需求目標

1. **建立排程架構**
   - 建立專門負責排程的模組或命名空間，例如：
     - `Scheduling` 或 `Infrastructure/Scheduling`。
   - 規劃排程相關的基本結構（如服務介面、註冊入口等），避免在各處直接依賴 Quartz 具體實作。

2. **導入與設定 Quartz**
   - 導入 Quartz 套件（依專案技術棧選擇對應套件）。
   - 在應用程式啟動流程中完成 Quartz 的基本註冊與初始化設定。
   - 目前僅需提供「可以被後續排程任務使用」的最小可行設定，暫不需實作實際 Job 或進階功能。

3. **簡易文件說明**
   - 在專案文件（如 README 或內部開發文件）中簡要說明：
     - 排程相關程式碼的放置位置與結構。
     - 未來要新增排程 Job 時，應該從哪裡擴充與接入現有架構。